### PR TITLE
Handle breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 GoTagLog is a simple command-line application to automatically generate a
 changelog from git tags based on the semantic versioning. It categorizes
 commits into groups and outputs them in a formatted markdown file or
-directly to the terminal with highlighting.
+directly to the terminal with highlighting. Commit messages following the
+Conventional Commits `!` breaking change convention are highlighted under a
+dedicated **Breaking Changes** section.
 
 ## Prerequisites
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -208,6 +208,7 @@ func getTagEntryDetails(repo *git.Repository, olderTag, newerTag *plumbing.Refer
 	}
 
 	groupedCommits := make(map[string][]string)
+	var breakingChanges []string
 
 	_ = commitIter.ForEach(func(c *object.Commit) error {
 		ancestor := false
@@ -223,6 +224,9 @@ func getTagEntryDetails(repo *git.Repository, olderTag, newerTag *plumbing.Refer
 
 		// Only print the first line of the commit message (the title)
 		title := strings.Split(c.Message, "\n")[0]
+		isBreaking := strings.Contains(title, "!:") ||
+			strings.Contains(strings.ToLower(c.Message), "breaking change:") ||
+			strings.Contains(strings.ToLower(c.Message), "breaking-change:")
 
 		for _, group := range commitGroups {
 			re := regexp.MustCompile(group.Message + "(\\(.*\\))?!?:.")
@@ -244,13 +248,25 @@ func getTagEntryDetails(repo *git.Repository, olderTag, newerTag *plumbing.Refer
 				cleanTitle := re.ReplaceAllString(title, "")
 				words := strings.Fields(cleanTitle)
 				words[0] = cases.Title(language.Und, cases.NoLower).String(words[0])
-				groupedCommits[group.Group] = append(groupedCommits[group.Group], strings.TrimSpace(strings.Join(append([]string{scope}, words...), " ")))
+				commitMsg := strings.TrimSpace(strings.Join(append([]string{scope}, words...), " "))
+				if isBreaking {
+					breakingChanges = append(breakingChanges, commitMsg)
+				} else {
+					groupedCommits[group.Group] = append(groupedCommits[group.Group], commitMsg)
+				}
 				break
 			}
 		}
 
 		return nil
 	})
+
+	if len(breakingChanges) > 0 {
+		entry += "\n### \U0001F4A5 Breaking Changes\n\n"
+		for _, commit := range breakingChanges {
+			entry += fmt.Sprintln("- " + commit)
+		}
+	}
 
 	for _, groupName := range commitGroups {
 		commits := groupedCommits[groupName.Group]


### PR DESCRIPTION
## Summary
- highlight breaking changes in changelog when commit message uses `!`
- document that breaking changes are called out

## Testing
- `go vet ./...`
- `go build ./...`
